### PR TITLE
Bump flyway to 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shumway</artifactId>
-    <version>1.1.13</version>
+    <version>1.1.14</version>
     <packaging>jar</packaging>
 
     <name>shumway</name>
@@ -109,6 +109,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.rbkmoney.woody</groupId>


### PR DESCRIPTION
В общем согласно гайду по переходу на spring boot 2.0, нам для начала нужно перевести flyway 3 на 4:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#flyway

В итоге получим:
```
Upgrading metadata table "public"."schema_version" to the Flyway 4.0 format ...
Repairing metadata for version 1 (Description: init, Checksum: -1715441086)  ...
Repairing metadata for version 2 (Description: 1.1.2, Checksum: 1849291050)  ...
Repairing metadata for version 3 (Description: 1.1.4, Checksum: 1702570498)  ...
Repairing metadata for version 4 (Description: 1.1.6, Checksum: -2146121325)  ...
```
а там уже 5-ой версии необходимости в миграции нет👌 